### PR TITLE
CPE Input Variable Picker

### DIFF
--- a/default/classes/FlowLauncherVariableController.cls
+++ b/default/classes/FlowLauncherVariableController.cls
@@ -1,0 +1,44 @@
+global with sharing class FlowLauncherVariableController {
+    @AuraEnabled(cacheable=true)
+    public static List<FlowVariableInfo> getFlowVariables(Id flowVersionViewId) {
+        List<FlowVariableInfo> variables = new List<FlowVariableInfo>();
+        
+        try {
+            // Query FlowVariableView records related to the given FlowVersionView
+            List<FlowVariableView> flowVars = [
+                SELECT ApiName, DataType, Description, IsCollection, ObjectType
+                FROM FlowVariableView
+                WHERE FlowVersionViewId = :flowVersionViewId
+                AND IsInput = true
+                ORDER BY ApiName ASC
+            ];
+            
+            // Convert to wrapper objects
+            for(FlowVariableView var : flowVars) {
+                variables.add(new FlowVariableInfo(var.ApiName, var.DataType, var.Description, var.IsCollection, var.ObjectType));
+            }
+        } catch(Exception e) {
+            System.debug('Error fetching flow variables: ' + e.getMessage());
+            throw new AuraHandledException('Error fetching flow variables: ' + e.getMessage());
+        }
+        
+        return variables;
+    }
+    
+    // Wrapper class to hold variable information
+    global class FlowVariableInfo {
+        @AuraEnabled public String apiName { get; set; }
+        @AuraEnabled public String dataType { get; set; }
+        @AuraEnabled public String description { get; set; }
+        @AuraEnabled public Boolean isCollection { get; set; }
+        @AuraEnabled public String objectType { get; set; }
+        
+        public FlowVariableInfo(String apiName, String dataType, String description, Boolean isCollection, String objectType) {
+            this.apiName = apiName;
+            this.dataType = dataType;
+            this.description = description;
+            this.isCollection = isCollection;
+            this.objectType = objectType;
+        }
+    }
+}

--- a/default/classes/FlowLauncherVariableController.cls-meta.xml
+++ b/default/classes/FlowLauncherVariableController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/default/classes/FlowLauncherVariableControllerTest.cls
+++ b/default/classes/FlowLauncherVariableControllerTest.cls
@@ -1,0 +1,35 @@
+@IsTest
+private class FlowLauncherVariableControllerTest {
+    @IsTest
+    static void testGetFlowVariables() {
+        // Create test data
+        // Note: Since FlowVersionView and FlowVariableView are special objects,
+        // we'll need to handle this differently in a real implementation
+        // This test demonstrates the structure but won't actually insert records
+        
+        Id flowVersionViewId = '301000000000000'; // Mock ID
+
+        String filters = '{"ProcessType":["Flow","AutolaunchedFlow"]}';
+        List<FlowDefinitionView> fdvs = FlowPickerController.getFlowNamesApex(filters);
+        if (fdvs.size()>0) {
+            flowVersionViewId = fdvs[0].LatestVersionId;
+        }
+        
+        // Test the method
+        Test.startTest();
+        try {
+            List<FlowLauncherVariableController.FlowVariableInfo> variables = 
+                FlowLauncherVariableController.getFlowVariables(flowVersionViewId);
+            
+            // Verify the method runs without throwing exceptions
+            System.assertNotEquals(null, variables, 'Should return a list, even if empty');
+            System.debug('variables: '+variables);
+            
+        } catch(Exception e) {
+            // Verify that any exception is an AuraHandledException
+            System.assert(e instanceof AuraHandledException, 
+                         'Should throw AuraHandledException for client-safe error messages');
+        }
+        Test.stopTest();
+    }
+}

--- a/default/classes/FlowLauncherVariableControllerTest.cls-meta.xml
+++ b/default/classes/FlowLauncherVariableControllerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/default/classes/FlowLauncherVersionInfoController.cls
+++ b/default/classes/FlowLauncherVersionInfoController.cls
@@ -1,0 +1,35 @@
+public with sharing class FlowLauncherVersionInfoController {
+    @AuraEnabled(cacheable=true)
+    public static FlowVersionInfo getFlowVersionInfo(String flowApiName) {
+        FlowVersionInfo versionInfo = new FlowVersionInfo();
+        
+        try {
+            FlowDefinitionView flowDef = [
+                SELECT ActiveVersionId, LatestVersionId 
+                FROM FlowDefinitionView 
+                WHERE ApiName = :flowApiName 
+                LIMIT 1
+            ];
+            
+            versionInfo.activeVersionId = flowDef.ActiveVersionId;
+            versionInfo.latestVersionId = flowDef.LatestVersionId;
+            versionInfo.hasError = false;
+            versionInfo.errorMessage = '';
+            
+        } catch (Exception e) {
+            versionInfo.hasError = true;
+            versionInfo.errorMessage = e.getMessage();
+            versionInfo.activeVersionId = null;
+            versionInfo.latestVersionId = null;
+        }
+        
+        return versionInfo;
+    }
+    
+    public class FlowVersionInfo {
+        @AuraEnabled public String activeVersionId;
+        @AuraEnabled public String latestVersionId;
+        @AuraEnabled public Boolean hasError;
+        @AuraEnabled public String errorMessage;
+    }
+}

--- a/default/classes/FlowLauncherVersionInfoController.cls-meta.xml
+++ b/default/classes/FlowLauncherVersionInfoController.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/default/classes/FlowLauncherVersionInfoControllerTest.cls
+++ b/default/classes/FlowLauncherVersionInfoControllerTest.cls
@@ -1,0 +1,17 @@
+@IsTest
+private class FlowLauncherVersionInfoControllerTest {
+    @IsTest
+    static void testGetFlowVersionInfo() {
+        String testFlowApiName = 'TestFlow';
+        
+        Test.startTest();
+        FlowLauncherVersionInfoController.FlowVersionInfo result = 
+            FlowLauncherVersionInfoController.getFlowVersionInfo(testFlowApiName);
+        Test.stopTest();
+        
+        // Since we can't create FlowDefinitionView records in tests,
+        // we'll verify the structure is correct
+        System.assertNotEquals(null, result, 'Should return a result object');
+        System.assertEquals(true, result.hasError, 'Should have error in test context');
+    }
+}

--- a/default/classes/FlowLauncherVersionInfoControllerTest.cls-meta.xml
+++ b/default/classes/FlowLauncherVersionInfoControllerTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>62.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/default/lwc/flowLauncherCPE/flowLauncherCPE.html
+++ b/default/lwc/flowLauncherCPE/flowLauncherCPE.html
@@ -9,10 +9,8 @@
     disabled={isNotShowFlowInModal} onchange={handleModalSizeChange}></lightning-combobox>
   <c-flow-picker name="flowToLaunch" label={inputValues.flowToLaunch.label} value={inputValues.flowToLaunch.value}
     show-active-flows-only onflowselect={handleFlowSelect}></c-flow-picker>
-  <c-flow-launcher-combobox name="flowInputVariableName" value={inputValues.flowInputVariableName.value}
-    label={inputValues.flowInputVariableName.label} builder-context={_builderContext}
-    automatic-output-variables={automaticOutputVariables}
-    onvaluechanged={handleFlowComboboxValueChange}></c-flow-launcher-combobox>
+  <lightning-combobox label={inputValues.flowInputVariableName.label} value={inputValues.flowInputVariableName.value} options={inputVariableOptions}
+    disabled={isNoFlowAPIName} placeholder={inputVariablePlaceholder} onchange={handleInputVariableChange}></lightning-combobox>
   <c-flow-launcher-combobox name="flowInputValue" value={inputValues.flowInputValue.value}
     label={inputValues.flowInputValue.label} builder-context={_builderContext}
     automatic-output-variables={automaticOutputVariables}

--- a/default/lwc/flowLauncherSObjectCPE/flowLauncherSObjectCPE.html
+++ b/default/lwc/flowLauncherSObjectCPE/flowLauncherSObjectCPE.html
@@ -12,10 +12,8 @@
     disabled={isNotShowFlowInModal} onchange={handleModalSizeChange}></lightning-combobox>
   <c-flow-picker name="flowToLaunch" label={inputValues.flowToLaunch.label} value={inputValues.flowToLaunch.value}
     show-active-flows-only onflowselect={handleFlowSelect}></c-flow-picker>
-  <c-flow-launcher-combobox name="flowInputVariableName" value={inputValues.flowInputVariableName.value}
-    label={inputValues.flowInputVariableName.label} builder-context={_builderContext}
-    automatic-output-variables={automaticOutputVariables}
-    onvaluechanged={handleFlowComboboxValueChange}></c-flow-launcher-combobox>
+  <lightning-combobox label={inputValues.flowInputVariableName.label} value={inputValues.flowInputVariableName.value} options={inputVariableOptions}
+    disabled={isNoFlowAPIName} placeholder={inputVariablePlaceholder} onchange={handleInputVariableChange}></lightning-combobox>
   <c-flow-launcher-combobox name="flowInputValue" value={inputValues.flowInputValue.value}
     label={inputValues.flowInputValue.label} builder-context={_builderContext}
     automatic-output-variables={automaticOutputVariables}

--- a/default/lwc/flowLauncherSObjectCPE/flowLauncherSObjectCPE.js
+++ b/default/lwc/flowLauncherSObjectCPE/flowLauncherSObjectCPE.js
@@ -1,4 +1,6 @@
-import { LightningElement, api, track } from 'lwc';
+import { LightningElement, api, track, wire } from 'lwc';
+import getFlowVariables from '@salesforce/apex/FlowLauncherVariableController.getFlowVariables';
+import getFlowVersionInfo from '@salesforce/apex/FlowLauncherVersionInfoController.getFlowVersionInfo';
 
 const DATA_TYPE = {
     STRING: 'String',
@@ -50,6 +52,64 @@ export default class flowLauncherCPE extends LightningElement {
     
         
     };
+
+    @api 
+    get selectedFlowApiName() {
+        return this._selectedFlowApiName;
+    }
+    set selectedFlowApiName(value) {
+        this._selectedFlowApiName = value;
+    }
+    _selectedFlowApiName;
+
+    @api 
+    get flowVersionViewId() {
+        return this._flowVersionViewId;
+    }
+    set flowVersionViewId(value) {
+        this._flowVersionViewId = value;
+    }
+    _flowVersionViewId;
+
+    error;
+    activeVersionId;
+    latestVersionId;
+
+    @wire(getFlowVersionInfo, { flowApiName: '$selectedFlowApiName' })
+    wiredFlowVersionInfo({ error, data }) {
+        if (data) {
+            if (data.hasError) {
+                this.error = { body: { message: data.errorMessage }};
+                this.activeVersionId = undefined;
+                this.latestVersionId = undefined;
+            } else {
+                this.activeVersionId = data.activeVersionId;
+                this.latestVersionId = data.latestVersionId;
+                this.error = undefined;
+            }
+        } else if (error) {
+            this.error = error;
+            this.activeVersionId = undefined;
+            this.latestVersionId = undefined;
+        }
+        this.flowVersionViewId = (!this.activeVersionId) ? this.latestVersionId : this.activeVersionId; // Use Latest Flow Version unless there is an Active Version then use that instead
+        this.processFlowInputVariables(this._flowVersionViewId);
+    }
+
+    get hasError() {
+        return this.error != null;
+    }
+
+    flowInputVariables;
+    inputVariableOptions;
+
+    get isNoFlowAPIName() {
+        return this._selectedFlowApiName == null || this._selectedFlowApiName == '';
+    }
+
+    get inputVariablePlaceholder() {
+        return (this.inputVariableOptions?.length == 0) ? 'The selected flow has no variables available for input' : 'Select Flow Input Variable';
+    }
 
     @api get builderContext() {
         return this._builderContext;
@@ -166,6 +226,9 @@ export default class flowLauncherCPE extends LightningElement {
                         this.inputValues[curInputParam.name].value = curInputParam.value;
                     }
                     this.inputValues[curInputParam.name].valueDataType = curInputParam.valueDataType;
+                    if (curInputParam.name == 'flowToLaunch' && curInputParam.value && curInputParam.value != null) {
+                        this.selectedFlowApiName = curInputParam.value;
+                    }
                 }
             });
         }
@@ -178,6 +241,32 @@ export default class flowLauncherCPE extends LightningElement {
                 this.typeValue = typeMapping.value;
             }
         });
+    }
+
+    processFlowInputVariables(flowVersionId) {
+        getFlowVariables({flowVersionViewId: flowVersionId})
+        .then((flowVariables) => {
+            this.flowInputVariables = flowVariables;
+            this.inputVariableOptions = [];
+            this.flowInputVariables.forEach(flowInputVariable => {
+                this.inputVariableOptions.push({
+                    label: flowInputVariable.apiName,
+                    value: flowInputVariable.apiName,
+                    description: this.processDescription(flowInputVariable.dataType, flowInputVariable.description, flowInputVariable.isCollection, flowInputVariable.objectType)
+                });
+            });
+        })
+        .catch(error => {
+            console.log("flowLauncherCPE ~ processFlowInputVariables ~ error:", error);
+            this.flowInputVariables = undefined;
+        });
+    }
+
+    processDescription(dataType, description, isCollection, objectType) {
+        let type = (dataType == 'sObject') ? `${objectType} Object` : dataType;
+        let isCol = (isCollection) ? ' Collection' : '';
+        let desc = (description && description != null) ? ` : ${description}` : '';
+        return `${type}${isCol}${desc}`;
     }
 
     /* EVENT HANDLERS */
@@ -256,8 +345,8 @@ export default class flowLauncherCPE extends LightningElement {
     }
 
     handleFlowSelect(event) {
-        
-            this.dispatchFlowValueChangeEvent('flowToLaunch', event.currentTarget.selectedFlowApiName, 'String');
+        this.selectedFlowApiName = event.currentTarget.selectedFlowApiName;
+        this.dispatchFlowValueChangeEvent('flowToLaunch', this._selectedFlowApiName, 'String');
         
     }
 
@@ -277,6 +366,10 @@ export default class flowLauncherCPE extends LightningElement {
         this.dispatchFlowValueChangeEvent('modalSize', event.detail.value, 'String');
     }
 
+    handleInputVariableChange(event) {
+        this.dispatchFlowValueChangeEvent('flowInputVariableName', event.detail.value, 'String');
+    }
+    
     get showButtonOptions() {
         if (this.inputValues.cb_hideButton.value == null || this.inputValues.cb_hideButton.value === 'CB_FALSE') {
             return true;
@@ -284,4 +377,3 @@ export default class flowLauncherCPE extends LightningElement {
         return false;
     }
     }
-   

--- a/default/lwc/flowPicker/flowPicker.js
+++ b/default/lwc/flowPicker/flowPicker.js
@@ -51,7 +51,8 @@ export default class flowPicker extends LightningElement {
             return this.flowDefinitions.map(curFD => {
                 return {
                     value: curFD.ApiName,
-                    label: curFD.Label
+                    label: curFD.Label,
+                    id: curFD.ActiveVersionId
                 }
             });
         } else {
@@ -64,7 +65,10 @@ export default class flowPicker extends LightningElement {
         const attributeChangeEvent = new FlowAttributeChangeEvent('selectedFlowApiName', this.selectedFlowApiName);
         this.dispatchEvent(attributeChangeEvent);
         let selectedFlow = this.options.find(option => this.selectedFlowApiName === option.value);
-        this.dispatchEvent(new CustomEvent('flowselect', { detail: { ...selectedFlow } }));
+        let activeFlowId = this.options.find(option => this.selectedFlowApiName === option.id);
+        console.log("🚀 ~ flowPicker ~ handleChange ~ activeFlowId:", activeFlowId);
+        this.dispatchEvent(new CustomEvent('flowselect', { detail: { ...selectedFlow} }));
+        // this.dispatchEvent(new CustomEvent('flowselect', { detail: { apiName: {...selectedFlow}, activeId: {...activeFlowId} } }));
         this.value = this.selectedFlowApiName;
     }
 


### PR DESCRIPTION
@jdayment I've changed the selection for "Flow Input Variable Name" to be a picklist of all of the "Available for input" attributes in the selected flow.  These will come from either the Active version of the flow or if no active version the Latest version of the flow.

The picklist will show the name and type of the attribute, if it is a collection, the object if it is an SObject type resource and any description for the attribute.

New components are 

- FlowLauncherVariableController
- FlowLauncherVariableControllerTest
- FlowLauncherVersionInfoController
- FlowLauncherVersionInfoControllerTest

Changed components are

- flowLauncherCPE
- flowLauncherSObjectCPE

I've attached a video of what it looks like in action.

https://github.com/user-attachments/assets/7ee5f941-b6d3-461c-bd44-d523778001b3

